### PR TITLE
fix handling of routes with bracketed params

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,8 +21,8 @@ module.exports = ({ routes }) => ({
       // console.log(code, routes);
 
       // construct regular expressons
-      const reBuild = /export[\ ]*const[\ ]*build[\ ]*\=[\ ]*(?<code>\[[^\[\]]*\])/;
-      const reFiles = /export[\ ]*const[\ ]*files[\ ]*\=[\ ]*(?<code>\[[^\[\]]*\])/;
+      const reBuild = /export[\ ]*const[\ ]*build[\ ]*\=[\ ]*(?<code>\[[\s\S]*?\n\]);/;
+      const reFiles = /export[\ ]*const[\ ]*files[\ ]*\=[\ ]*(?<code>\[[\s\S]*?\n\]);/;
 
       // extract build files
       // const build = JSON.parse(code.match(reBuild)?.groups?.code || []);


### PR DESCRIPTION
The regex for caching routes was unable to handle routes
with parameters, like `[slug].svelte`. This was fixed by changing
`[^\[\]]*\]` (any text not including brackets, followed by bracket)
to `[\s\S]*?\n\]` (any text up to a bracket following a newline).